### PR TITLE
Make immutable a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,10 +6,10 @@
   "repository": "git://github.com/jasonphillips/slate-deep-table.git",
   "main": "./dist/index.js",
   "dependencies": {
-    "immutable": "^3.8.1",
     "slate-html-serializer": "^0.7.20"
   },
   "peerDependencies": {
+    "immutable": ">=3.8.1",
     "react": "^0.14.0 || ^15.0.0 || ^16.0.0",
     "react-dom": "^0.14.0 || ^15.0.0 || ^16.0.0",
     "slate": "0.43.x"
@@ -27,6 +27,7 @@
     "expect": "^1.20.2",
     "gh-pages": "^0.11.0",
     "http-server": "^0.9.0",
+    "immutable": "^3.8.1",
     "mocha": "^3.0.1",
     "react": "^15.3.0",
     "react-dom": "^15.3.0",


### PR DESCRIPTION
Like slate: https://github.com/ianstormtaylor/slate/blob/5cca509db239f1025d8b34bccfd9e0cb53f70735/packages/slate/package.json#L26

This allows the consumer to specify their own version of immutable